### PR TITLE
changeQuantity에서 CartItem id null 비교로 인한 NPE 수정

### DIFF
--- a/src/main/java/com/shoppingmall/ecommerceapi/domain/cart/service/CartService.java
+++ b/src/main/java/com/shoppingmall/ecommerceapi/domain/cart/service/CartService.java
@@ -95,7 +95,7 @@ public class CartService {
     return item;
   }
 
-  
+
   public CartItem changeQuantity(Long userId, Long cartItemId, int quantity) {
     Cart cart = getCartByUserId(userId);
 
@@ -104,7 +104,7 @@ public class CartService {
     }
 
     CartItem item = cart.getItems().stream()
-        .filter(i -> i.getId().equals(cartItemId)) // ID 기준
+        .filter(i -> cartItemId.equals(i.getId()))// ID 기준
         .findFirst()
         .orElseThrow(() -> new BusinessException(CartErrorCode.CART_ITEM_NOT_FOUND));
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

changeQuantity에서 CartItem id null 비교로 인한 NPE 수정
- cartItemId.equals(i.getId())로 null-safe 비교 적용
- changeQuantity_notFound 테스트 케이스 정상 동작 보장


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?