### PR TITLE
전역 예외처리에서 MissingRequestHeaderException을 500으로 처리하던 문제 수정 

### DIFF
--- a/src/main/java/com/shoppingmall/ecommerceapi/common/code/CommonErrorCode.java
+++ b/src/main/java/com/shoppingmall/ecommerceapi/common/code/CommonErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ApiCode {
 
   BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 요청"),
+  MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST.value(), 400, "필수 헤더가 누락되었습니다"),
   SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버 에러");
 
   private final Integer httpStatus;

--- a/src/main/java/com/shoppingmall/ecommerceapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shoppingmall/ecommerceapi/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.shoppingmall.ecommerceapi.common.code.ApiCode;
 import com.shoppingmall.ecommerceapi.common.code.CommonErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,8 +15,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<Api<Object>> handleBusiness(BusinessException e) {
     ApiCode code = e.getCode();
-
-    // description이 없으면 기본 메시지로 내려도 됨(팀 룰에 맞게)
+    
     String description = (e.getDescription() != null) ? e.getDescription() : code.getMessage();
 
     return ResponseEntity
@@ -39,5 +39,16 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(CommonErrorCode.BAD_REQUEST.getHttpStatus())
         .body(Api.ERROR(CommonErrorCode.BAD_REQUEST, errorMessage));
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<Api<Object>> handleMissingRequestHeader(MissingRequestHeaderException e) {
+    ApiCode code = CommonErrorCode.MISSING_REQUIRED_HEADER;
+
+    String description = "필수 헤더(" + e.getHeaderName() + ")가 누락되었습니다.";
+
+    return ResponseEntity
+        .status(code.getHttpStatus())
+        .body(Api.ERROR(code, description));
   }
 }


### PR DESCRIPTION


## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#15 
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 공통 에러코드에 MISSING_REQUIRED_HEADER 추가
- GlobalExceptionHandler 에서 MissingRequestHeaderException을 BAD_REQUEST로 처리
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?