### PR TITLE
Api 응답 코드에 따라 HTTP status 동기화

### DIFF
--- a/src/main/java/com/shoppingmall/ecommerceapi/common/aop/ApiResponseAdvice.java
+++ b/src/main/java/com/shoppingmall/ecommerceapi/common/aop/ApiResponseAdvice.java
@@ -1,0 +1,50 @@
+package com.shoppingmall.ecommerceapi.common.aop;
+
+import com.shoppingmall.ecommerceapi.common.api.Api;
+import com.shoppingmall.ecommerceapi.common.api.Result;
+import com.shoppingmall.ecommerceapi.common.code.CommonResultCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return Api.class.isAssignableFrom(returnType.getParameterType());
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+
+        if (!(body instanceof Api<?> apiBody)) return body;
+
+        HttpServletResponse servletResponse =
+                ((ServletServerHttpResponse) response).getServletResponse();
+
+        Result result = apiBody.getResult();
+        if (result == null || result.getCode() == null) return apiBody;
+
+        // 핵심: Integer(201/200)로 비교
+        if (result.getCode().equals(CommonResultCode.CREATED.getCode())) {
+            servletResponse.setStatus(HttpStatus.CREATED.value()); // 201
+        } else if (result.getCode().equals(CommonResultCode.OK.getCode())) {
+            servletResponse.setStatus(HttpStatus.OK.value());      // 200
+        }
+
+        return apiBody;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#64
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Api.CREATED(...)처럼 공통 응답을 유지하면서도, 실제 HTTP 응답은 201(Created) 등 의미에 맞는 Status로 반환되도록 개선

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?